### PR TITLE
Implement list items in order endpoint

### DIFF
--- a/service/models/item.py
+++ b/service/models/item.py
@@ -89,3 +89,13 @@ class Item(db.Model, PersistentBase):
         """
         logger.info("Processing name query for %s ...", name)
         return cls.query.filter(cls.name == name)
+
+    @classmethod
+    def find_by_order_id(cls, order_id):
+        """Returns all Items with the given order_id
+
+        Args:
+            order_id (int): the order_id of the Items you want to match
+        """
+        logger.info("Processing order_id query for %s ...", order_id)
+        return cls.query.filter(cls.order_id == order_id)

--- a/service/routes.py
+++ b/service/routes.py
@@ -214,6 +214,35 @@ def create_items(order_id):
 
 
 ######################################################################
+# LIST ALL ITEMS IN AN ORDER
+######################################################################
+@app.route("/orders/<int:order_id>/items", methods=["GET"])
+def list_items(order_id):
+    """
+    List all Items in an Order
+
+    This endpoint returns all items associated with a specific order
+    """
+    app.logger.info("Request to list Items for Order id: %s", order_id)
+
+    # See if the order exists and abort if it doesn't
+    order = Order.find(order_id)
+    if not order:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Order with id '{order_id}' could not be found.",
+        )
+
+    # Get all items for this order
+    items = Item.find_by_order_id(order_id)
+
+    # Return as an array of dictionaries
+    results = [item.serialize() for item in items]
+
+    return jsonify(results), status.HTTP_200_OK
+
+
+######################################################################
 # READ AN ITEM
 ######################################################################
 @app.route("/orders/<int:order_id>/items/<int:item_id>", methods=["GET"])


### PR DESCRIPTION
What I did in this branch:
1. Added a lookup method in the Item model
- Added a new class method `find_by_order_id` in `/app/service/models/item.py`.

2. Implemented a new API endpoint
- Added GET /orders/<order_id>/items endpoint in `/app/service/routes.py`.

3. Added three test cases in /app/tests/test_routes.py:
- `test_list_items()`: Tests listing all items in an order under normal conditions.
- `test_list_items_empty_order()`: Tests the case when an order has no items.
- `test_list_items_order_not_found()`: Tests that a non-existent order returns a 404 response.